### PR TITLE
Out-of-order startup fix.

### DIFF
--- a/ProgramAssignment1/main.cpp
+++ b/ProgramAssignment1/main.cpp
@@ -22,8 +22,8 @@ int main(int argc, char* argv[])
     auto nextTime = std::chrono::time_point_cast<time_point::duration>(std::chrono::system_clock::now() + std::chrono::seconds(timeInterval));
     
     // Start up functions.
-    handler->StartupFunction();
     handler->SetInputWindow(inputWindow);
+    handler->StartupFunction();
     
     // Main Loop
     while(bProgramStillRunning != false)


### PR DESCRIPTION
Out-of-order start-up function in the main.cpp that could lead to errors. 

Moved WellHandler::SetInputWindow(InputWindow* input) before WellHandler::StartupFunction().